### PR TITLE
fixed typo in accounts/models.py

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -11,12 +11,12 @@ from .validators import ASCIIUsernameValidator
 
 
 # LEVEL_COURSE = "Level course"
-BACHLOAR_DEGREE = "Bachloar"
+BACHELOR_DEGREE = "Bachelor"
 MASTER_DEGREE = "Master"
 
 LEVEL = (
     # (LEVEL_COURSE, "Level course"),
-    (BACHLOAR_DEGREE, "Bachloar Degree"),
+    (BACHELOR_DEGREE, "Bachelor Degree"),
     (MASTER_DEGREE, "Master Degree"),
 )
 


### PR DESCRIPTION
#55 fixed the typo in `course/model`, but the same typo remains in `accounts/model`. This PR fixes that.